### PR TITLE
ci: skip ci when not necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: commit_message !~ /^(docs|style|chore)(\(.*\))?:/
+
 language: node_js
 cache:
   directories:


### PR DESCRIPTION
some of the changes don't need a CI to be ran, e.g. docs, styles, and chore changes

close #14